### PR TITLE
fix problem with long bam headers

### DIFF
--- a/pybam.py
+++ b/pybam.py
@@ -343,7 +343,7 @@ class read():
         p_from = p_to; p_to += 4
         length_of_header = unpack('<i',header_cache[p_from:p_to])[0]
         p_from = p_to; p_to += length_of_header
-        while len(header_cache) < p_to: header_cache += str(next(self._generator))
+        while len(header_cache) < p_to: header_cache += next(self._generator)
         self.file_header = header_cache[p_from:p_to]
         p_from = p_to; p_to += 4
         while len(header_cache) < p_to: header_cache += str(next(self._generator))


### PR DESCRIPTION
pybam has a problem with bam files that have long headers:

  File "/foo/bar/pybam.py", line 346, in __init__
    while len(header_cache) < p_to: header_cache += str(next(self._generator))
TypeError: can't concat str to bytes

